### PR TITLE
Kill lingering sound processes before exiting scripts

### DIFF
--- a/M8/M8.sh
+++ b/M8/M8.sh
@@ -28,4 +28,6 @@ fi
 alsaloop -P hw:0,0 -C hw:1,0 -t 50000 -B 5000 --rate 44100 --sync=0 -d
 ./_m8c/m8c
 
+procId=$(ps -ef | grep 'alsaloop' | grep -v 'grep' | awk '{ printf $2 }')
+kill $procId
 

--- a/M8/M8_pulse.sh
+++ b/M8/M8_pulse.sh
@@ -27,3 +27,6 @@ fi
 sudo pulseaudio --start --file=_other_files/pulseaudio_config.pa
 
 ./_m8c/m8c
+
+procId=$(ps -ef | grep '_other_files/pulseaudio' | grep -v 'grep' | awk '{ printf $2 }')
+sudo kill $procId


### PR DESCRIPTION
need to kill the alsa and pulse processes  when the script ends or the audio on the rg351v doesn't work most of the time. Always works after I added the kill process command. in the shell scripts.